### PR TITLE
force termination of mutatex if there are unrecognized molecules

### DIFF
--- a/bin/mutatex
+++ b/bin/mutatex
@@ -23,10 +23,11 @@ import argparse
 import logging as log
 import numpy as np
 import platform
+import shutil
 from Bio import PDB
 from six import iteritems
 from mutatex.utils import *
-from mutatex.core import * 
+from mutatex.core import *
 
 signal.signal(signal.SIGTERM, termination_handler)
 signal.signal(signal.SIGINT, termination_handler)
@@ -89,6 +90,9 @@ parser.add_argument('-l', '--foldx-log',
 parser.add_argument('-R', '--repair-runfile-template','--repair', 
                         dest="repair_runfile_template", type=str, default="repair_runfile_template.txt", 
                         help="template runfile for repair runs (default: ./repair_runfile_template.txt)")
+parser.add_argument('-r', '--ignore_unrecognized_molecules',
+                        dest="force_run_repair", action='store_true',
+                        help="Force repair of PDB even if there is unrecognized molecules")
 parser.add_argument('-M', '--mutate-runfile-template','--mutate', 
                         dest="mutate_runfile_template", type=str, default="mutate_runfile_template.txt", 
                         help="template runfile for mutation runs (default: ./mutate_runfile_template.txt)")
@@ -269,6 +273,9 @@ else:
     # Prepare repair runs
     for r in repair_runs:
         log.info("Preparing for repair run %s" % (r.name))
+        if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)):
+            log.info("Files from existing repair run in %s removed" % (r.name))
+            shutil.rmtree("%s/%s/" % (working_directory, r.name))
         r.prepare()
 
     # Run repair runs
@@ -281,12 +288,16 @@ else:
         log.error("\t%s" % i[0])
         exit(1)
 
+#TEHI
     # Detect unrecognized molecule files.
-    for r in repair_runs:
-        if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)): 
-            log.info("unrecognized molecles in the pdb structure after repair run of %s" % (r.name))
-            log.info("MutateX terminated due to unrecognized molecules")
-            sys.exit()
+    if args.force_run_repair:
+        pass
+    else:
+        for r in repair_runs:
+            if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)): 
+                log.info("unrecognized molecles in the pdb structure after repair run of %s" % (r.name)) 
+                log.info("MutateX terminated due to unrecognized molecules") 
+                sys.exit()
 
     # Select PDB(s) to be used
     repaired_pdbs_list = [repair_runs[i].working_directory+"/"+current_version.repair_pdb_output_fname(pdbs_list[i]) for i in range(len(pdbs_list))]

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -26,6 +26,7 @@ import platform
 from Bio import PDB
 from six import iteritems
 from mutatex.utils import *
+from mutatex.core import *
 
 signal.signal(signal.SIGTERM, termination_handler)
 signal.signal(signal.SIGINT, termination_handler)
@@ -286,6 +287,7 @@ else:
 
 
 # PHASE TWO: mutate + energy
+
 
 # create working directory
 working_directory = main_dir+"/"+mutations_dirname

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -274,10 +274,9 @@ else:
     # Run repair runs
     log.info("Running repair runs")
     repair_outcome = parallel_foldx_run(repair_runs, np=args.np)
-    log.info(f"{repair_outcome}")
 
     if False in list(zip(*repair_outcome))[1]:
-        #this needs to be te case when unrecognized molecules are found.
+        #applicable when unrecognized molecules are found.
         log.error("The following repair runs failed to complete. Exiting...")
     for i in [x for x in repair_outcome if x[1] == False]:
         log.error("\t%s" % i[0])

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -288,7 +288,6 @@ else:
         log.error("\t%s" % i[0])
         exit(1)
 
-#TEHI
     # Detect unrecognized molecule files.
     if args.force_run_repair:
         pass

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -281,13 +281,19 @@ else:
         log.error("\t%s" % i[0])
         exit(1)
 
+    # Detect unrecognized molecule files.
+    for r in repair_runs:
+        if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)): 
+            log.info("unrecognized molecles in the pdb structure after repair run of %s" % (r.name))
+            log.info("MutateX terminated due to unrecognized molecules")
+            sys.exit()
+
     # Select PDB(s) to be used
     repaired_pdbs_list = [repair_runs[i].working_directory+"/"+current_version.repair_pdb_output_fname(pdbs_list[i]) for i in range(len(pdbs_list))]
     log.info("list of PDBs to be used: %s" % ", ".join(repaired_pdbs_list))
 
 
 # PHASE TWO: mutate + energy
-
 
 # create working directory
 working_directory = main_dir+"/"+mutations_dirname

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -274,8 +274,10 @@ else:
     # Run repair runs
     log.info("Running repair runs")
     repair_outcome = parallel_foldx_run(repair_runs, np=args.np)
+    log.info(f"{repair_outcome}")
 
     if False in list(zip(*repair_outcome))[1]:
+        #this needs to be te case when unrecognized molecules are found.
         log.error("The following repair runs failed to complete. Exiting...")
     for i in [x for x in repair_outcome if x[1] == False]:
         log.error("\t%s" % i[0])

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -23,11 +23,9 @@ import argparse
 import logging as log
 import numpy as np
 import platform
-import shutil
 from Bio import PDB
 from six import iteritems
 from mutatex.utils import *
-from mutatex.core import *
 
 signal.signal(signal.SIGTERM, termination_handler)
 signal.signal(signal.SIGINT, termination_handler)
@@ -90,9 +88,6 @@ parser.add_argument('-l', '--foldx-log',
 parser.add_argument('-R', '--repair-runfile-template','--repair', 
                         dest="repair_runfile_template", type=str, default="repair_runfile_template.txt", 
                         help="template runfile for repair runs (default: ./repair_runfile_template.txt)")
-parser.add_argument('-r', '--ignore_unrecognized_molecules',
-                        dest="force_run_repair", action='store_true',
-                        help="Force repair of PDB even if there is unrecognized molecules")
 parser.add_argument('-M', '--mutate-runfile-template','--mutate', 
                         dest="mutate_runfile_template", type=str, default="mutate_runfile_template.txt", 
                         help="template runfile for mutation runs (default: ./mutate_runfile_template.txt)")
@@ -273,9 +268,6 @@ else:
     # Prepare repair runs
     for r in repair_runs:
         log.info("Preparing for repair run %s" % (r.name))
-        if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)):
-            log.info("Files from existing repair run in %s removed" % (r.name))
-            shutil.rmtree("%s/%s/" % (working_directory, r.name))
         r.prepare()
 
     # Run repair runs
@@ -287,16 +279,6 @@ else:
     for i in [x for x in repair_outcome if x[1] == False]:
         log.error("\t%s" % i[0])
         exit(1)
-
-    # Detect unrecognized molecule files.
-    if args.force_run_repair:
-        pass
-    else:
-        for r in repair_runs:
-            if os.path.exists("%s/%s/Unrecognized_molecules.txt" % (working_directory, r.name)): 
-                log.info("unrecognized molecles in the pdb structure after repair run of %s" % (r.name)) 
-                log.info("MutateX terminated due to unrecognized molecules") 
-                sys.exit()
 
     # Select PDB(s) to be used
     repaired_pdbs_list = [repair_runs[i].working_directory+"/"+current_version.repair_pdb_output_fname(pdbs_list[i]) for i in range(len(pdbs_list))]

--- a/mutatex/core.py
+++ b/mutatex/core.py
@@ -914,7 +914,7 @@ class FoldXRun(object):
 
         elif returncode == 0:
             if self.check_output(**self.output_check): 
-                log.info("run %s was terminated after the repair step, since FoldX found unrecognized molecules." % self.name)
+                log.warning("run %s was terminated after the repair step, since FoldX found unrecognized molecules." % self.name)
                 return False
             else: 
                 log.info("run %s has completed successfully" % self.name)
@@ -1039,7 +1039,7 @@ class FoldXRepairRun(FoldXRun):
         checks status of the repair run. Since we are just interested in the
         repaired PDB, three statuses are possible: 1) the output PDB is
         present and the run was thus successful, 2) the output PDB was generated
-        with unrezognized molecules, or 3) the run was not sucessful.
+        with unrecognized molecules, or 3) the run was not sucessful.
         Returns
         ----------
         str
@@ -1087,8 +1087,8 @@ class FoldXRepairRun(FoldXRun):
         
         Returns
         ----------
-        True or False: bool 
-            signals if the working directory has been reset
+        bool:
+            True if the working directory has been reset, otherwise False
 
         """
         ftypes = [".pdb", ".fxout", ".log"]


### PR DESCRIPTION
Fix issue #92 by introducing a step after the repair to control the presence of unrecognized molecules. The user should reevaluate their PDB before restarting the run. 