### PR TITLE
Fixes calls to `parse_poslist` after merge of #128

### DIFF
--- a/bin/ddg2density
+++ b/bin/ddg2density
@@ -145,7 +145,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, residue_list)
     except (IOError, TypeError):
         exit(1)
 

--- a/bin/ddg2dg
+++ b/bin/ddg2dg
@@ -87,7 +87,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, foldx_sequence)
     except (IOError, TypeError):
         exit(1)
 

--- a/bin/ddg2distribution
+++ b/bin/ddg2distribution
@@ -333,7 +333,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, res_ids_str)
     except (IOError, TypeError):
         exit(1)
 

--- a/bin/ddg2excel
+++ b/bin/ddg2excel
@@ -73,7 +73,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, res_ids_str)
     except (IOError, TypeError):
         exit(1)
 

--- a/bin/ddg2heatmap
+++ b/bin/ddg2heatmap
@@ -190,7 +190,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, res_ids_str)
     except (IOError, TypeError):
         exit(1)
 

--- a/bin/ddg2logo
+++ b/bin/ddg2logo
@@ -251,7 +251,7 @@ except IOError:
 if options.position_list is not None:
     log.info("Positions will be read from file")
     try:
-        poslist = parse_poslist_file(options.position_list)
+        poslist = parse_poslist_file(options.position_list, res_ids_str)
     except (IOError, TypeError):
         exit(1)
 


### PR DESCRIPTION
fixes #152

in particular, fixes a regression from #128 - we should have updated all function calls to the `parse_poslist` function that we modified in that case PR, in all the analysis tools.