### PR TITLE
residue number control

### DIFF
--- a/bin/mutatex
+++ b/bin/mutatex
@@ -321,6 +321,9 @@ unique_residues = tuple(set(residues_list))
 if len(unique_residues) != 1:
     log.error("The supplied PDB files must have identical sequences. Exiting...")
     exit(1)
+if unique_residues[0][0] == 'RESIDUENUMBERING':
+    log.error("The supplied PDB files must have identical residue ID for identical sequence. Exiting...")
+    exit(1)
 
 unique_residues = list(unique_residues[0])
 

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -315,6 +315,9 @@ for pdb in repaired_pdbs_list:
             residues_list.append(get_foldx_sequence(pdb, multimers=args.multimers))
         except IOError:
             exit(1)
+        except ValueError as e:
+            log.error(f"{e}. Exiting...")
+            exit(1)
 
 unique_residues = tuple(set(residues_list))
 

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -316,14 +316,16 @@ for pdb in repaired_pdbs_list:
         except IOError:
             exit(1)
 
+for i in residues_list:
+    if "RESIDUE_MISMATCH" in i:
+        log.error("The supplied PDB files must have identical positions of sequences. Exiting...")
+        exit(1)
+
 unique_residues = tuple(set(residues_list))
 
 if len(unique_residues) != 1:
     log.error("The supplied PDB files must have identical sequences. Exiting...")
-    exit(1)
-if unique_residues[0][0] == 'RESIDUENUMBERING':
-    log.error("The supplied PDB files must have identical residue ID for identical sequence. Exiting...")
-    exit(1)
+    exit(1)    
 
 unique_residues = list(unique_residues[0])
 

--- a/bin/mutatex
+++ b/bin/mutatex
@@ -316,16 +316,11 @@ for pdb in repaired_pdbs_list:
         except IOError:
             exit(1)
 
-for i in residues_list:
-    if "RESIDUE_MISMATCH" in i:
-        log.error("The supplied PDB files must have identical positions of sequences. Exiting...")
-        exit(1)
-
 unique_residues = tuple(set(residues_list))
 
 if len(unique_residues) != 1:
     log.error("The supplied PDB files must have identical sequences. Exiting...")
-    exit(1)    
+    exit(1)
 
 unique_residues = list(unique_residues[0])
 

--- a/mutatex/utils.py
+++ b/mutatex/utils.py
@@ -451,10 +451,13 @@ def get_foldx_sequence(pdb, multimers=True):
         unique_seqs, unique_idxs = np.unique(seqs, return_inverse=True)
         unique_pos, unique_idxp = np.unique(pos, return_inverse=True)
         
-        if (unique_idxs == unique_idxp).all() == False:
-            log.warning("Input amino acid sequence and input position sequence is not identical in multimer.")
-            residue_list.append("RESIDUE_MISMATCH")
-            return tuple(residue_list)
+        try:
+            if not (unique_idxs == unique_idxp).all():
+                log.warning("Input amino acid sequence and input position sequence is not identical in multimer.")
+                raise ValueError
+        except ValueError as e:
+            log.error("The supplied PDB files must have identical positions of sequences. Exiting...")
+            exit(1)
 
         for i in np.unique(unique_idxs):
             collated_chains.append(seq_ids[unique_idxs == i])
@@ -467,11 +470,11 @@ def get_foldx_sequence(pdb, multimers=True):
                         res_code = PDB.Polypeptide.three_to_one(residue.get_resname())
                     except:
                         log.warning("Residue %s in file %s couldn't be recognized; it will be skipped" %(residue, pdb))
-                        continue                        
-                    
+                        continue
+
                     this_res = tuple(sorted([ "%s%s%d" % (res_code, c, resid) for c in cg ], key=lambda x: x[1]))
                     residue_list.append(this_res)
-                    
+
     return tuple(residue_list)
 
 def safe_makedirs(dirname):

--- a/mutatex/utils.py
+++ b/mutatex/utils.py
@@ -396,7 +396,6 @@ def get_residue_list(infile, multimers=True, get_structure=False):
 # Helper functions for the main script #
 ########################################
 
-
 def get_foldx_sequence(pdb, multimers=True):
     """
     Reads a PDB file and returns a list of residus (number, type and chain)
@@ -412,7 +411,9 @@ def get_foldx_sequence(pdb, multimers=True):
     restypes : list of str
         list of single-letter residue types
     """
+
     parser = PDB.PDBParser()
+
     try:
         structure = parser.get_structure("structure", pdb)
     except:
@@ -421,13 +422,17 @@ def get_foldx_sequence(pdb, multimers=True):
 
     residue_list = []
     sequences = {}
+    positions = {}
+
     for model in structure:
         for chain in model:
             chain_name = chain.get_id()
             sequences[chain_name] = ''
+            positions[chain_name] = ''
             for residue in chain:
                 try:
                     res_code = PDB.Polypeptide.three_to_one(residue.get_resname())
+                    pos_code = str(residue.get_id()[1])
                 except:
                     log.warning("Residue %s in file %s couldn't be recognized; it will be skipped" %(residue, pdb))
                     continue
@@ -435,29 +440,41 @@ def get_foldx_sequence(pdb, multimers=True):
                     residue_list.append(tuple(["%s%s%d" % (res_code, chain.get_id(), residue.get_id()[1])]))
                 else:
                     sequences[chain_name] += res_code
+                    positions[chain_name] += pos_code
 
     if multimers:
-        collated_chains = []
+        collated_chains_pos = []
+        collated_chains_seq = []
         seq_ids, seqs = list(zip(*list(iteritems(sequences))))
+        pos_ids, pos = list(zip(*list(iteritems(positions))))
         seq_ids = np.array(seq_ids)
+        pos_ids = np.array(pos_ids)
+
         unique_seqs, unique_idxs = np.unique(seqs, return_inverse=True)
+        unique_pos, unique_idxp = np.unique(pos, return_inverse=True)
 
+        for i in np.unique(unique_idxp):
+            collated_chains_pos.append(pos_ids[unique_idxp == i])
         for i in np.unique(unique_idxs):
-            collated_chains.append(seq_ids[unique_idxs == i])
+            collated_chains_seq.append(seq_ids[unique_idxs == i])
 
-        for cg in collated_chains:
-            for model in structure:
-                for residue in model[cg[0]]:
-                    resid = residue.get_id()[1]
-                    try:
-                        res_code = PDB.Polypeptide.three_to_one(residue.get_resname())
-                    except:
-                        log.warning("Residue %s in file %s couldn't be recognized; it will be skipped" %(residue, pdb))
-                        continue
-                    this_res = tuple(sorted([ "%s%s%d" % (res_code, c, resid) for c in cg ], key=lambda x: x[1]))
-                    residue_list.append(this_res)
+        if len(collated_chains_seq) > len(collated_chains_pos) or len(collated_chains_seq) == len(collated_chains_pos):
+            for cg in collated_chains_seq:
+                for model in structure:
+                    for residue in model[cg[0]]:
+                        resid = residue.get_id()[1]
+                        try:
+                            res_code = PDB.Polypeptide.three_to_one(residue.get_resname())
+                        except:
+                            log.warning("Residue %s in file %s couldn't be recognized; it will be skipped" %(residue, pdb))
+                            continue
+                        this_res = tuple(sorted([ "%s%s%d" % (res_code, c, resid) for c in cg ], key=lambda x: x[1]))
+                        residue_list.append(this_res)
+            return tuple(residue_list)
 
-    return tuple(residue_list)
+        else:
+            residue_list.append("RESIDUENUMBERING")
+            return tuple(residue_list)
 
 def safe_makedirs(dirname):
     """

--- a/mutatex/utils.py
+++ b/mutatex/utils.py
@@ -451,13 +451,9 @@ def get_foldx_sequence(pdb, multimers=True):
         unique_seqs, unique_idxs = np.unique(seqs, return_inverse=True)
         unique_pos, unique_idxp = np.unique(pos, return_inverse=True)
         
-        try:
-            if not (unique_idxs == unique_idxp).all():
-                log.warning("Input amino acid sequence and input position sequence is not identical in multimer.")
-                raise ValueError
-        except ValueError as e:
-            log.error("The supplied PDB files must have identical positions of sequences. Exiting...")
-            exit(1)
+        if not (unique_idxs == unique_idxp).all():
+            log.warning("Input amino acid sequence and input position sequence is not identical in multimer.")
+            raise ValueError("The supplied PDB files must have identical positions of sequences")
 
         for i in np.unique(unique_idxs):
             collated_chains.append(seq_ids[unique_idxs == i])


### PR DESCRIPTION
fix #142 - changes in two scripts: 
* mutatex/utils.py: Update the get_foldx_sequence(pdb, multimers=True) function, which already conduct a sequence control, to have a position control for multimers as well. The function only alters its regular output if there is a different number of unique chains when comparing the amino acid sequence and position numerical sequence. 

* bin/mutatex: call the utils function and adds a line to the .log file if the positioning is different. 