### PR TITLE
Fixes residue recognition in `ddg2histogram`

### DIFF
--- a/bin/ddg2histo
+++ b/bin/ddg2histo
@@ -83,8 +83,9 @@ def parse_residues(residues, fnames, single_res_ids):
                 log.error("Selection: '%s' invalid residue format. Exiting..." %(residue))
                 exit(1)
 
-            match = [s for s in fnames if residue in s]
-            if(len(match) == 1):
+            match = [s for s in fnames if residue == s]
+            assert len(match) == 1 or len(match) == 0
+            if len(match) == 1:
                 selections += match
                 log.info("Pdb file matched single residue %s" % (residue))
             else:


### PR DESCRIPTION
fixes #189

we were using `is in` instead of `==` to do string comparison, when validating and filtering the list of requested residues; this made it so that a residue could match more than once, and this case wasn't handled correctly